### PR TITLE
Adafruit Feather ESP32-S3 TFT board support

### DIFF
--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -536,6 +536,14 @@ class LGFX : public lgfx::LGFX_Device
             cfg.offset_x = 0;
             cfg.offset_y = 0;                             // No vertical shift needed — panel is top-aligned
             cfg.offset_rotation = 2;                      // Rotate 180° to correct upside-down layout
+#elif defined(ST7789_ALT)
+            cfg.memory_width = TFT_WIDTH;              // Maximum width supported by the driver IC
+            cfg.memory_height = TFT_HEIGHT;            // Maximum height supported by the driver IC
+            cfg.panel_width = TFT_PANEL_WIDTH;         // actual displayable width
+            cfg.panel_height = TFT_PANEL_HEIGHT;       // actual displayable height
+            cfg.offset_x = TFT_OFFSET_X;               // Panel offset amount in X direction
+            cfg.offset_y = TFT_OFFSET_Y;               // Panel offset amount in Y direction
+            cfg.offset_rotation = TFT_OFFSET_ROTATION; // Rotation direction value offset 0~7 (4~7 is mirrored)
 #else
             cfg.memory_width = TFT_WIDTH;              // Maximum width supported by the driver IC
             cfg.memory_height = TFT_HEIGHT;            // Maximum height supported by the driver IC

--- a/src/mesh/RF95Interface.cpp
+++ b/src/mesh/RF95Interface.cpp
@@ -9,6 +9,9 @@
 #include "PortduinoGlue.h"
 #endif
 
+// Global variable from main.cpp
+extern unsigned long last_listen;
+
 #if ARCH_PORTDUINO
 #define RF95_MAX_POWER portduino_config.rf95_max_power
 #endif
@@ -297,6 +300,7 @@ void RF95Interface::startReceive()
         LOG_ERROR("RF95 startReceive %s%d", radioLibErr, err);
     assert(err == RADIOLIB_ERR_NONE);
 
+    last_listen = millis();
     isReceiving = true;
 
     // Must be done AFTER, starting receive, because startReceive clears (possibly stale) interrupt pending register bits

--- a/variants/esp32s3/adafruit_feather_esp32s3_tft/pins_arduino.h
+++ b/variants/esp32s3/adafruit_feather_esp32s3_tft/pins_arduino.h
@@ -1,0 +1,19 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+// The default Wire will be mapped to PMU and RTC
+static const uint8_t SDA = 42;
+static const uint8_t SCL = 41;
+
+// Default SPI will be mapped to Radio
+static const uint8_t MISO = 37;
+static const uint8_t SCK = 36;
+static const uint8_t MOSI = 35;
+static const uint8_t SS = 6;
+
+#endif /* Pins_Arduino_h */

--- a/variants/esp32s3/adafruit_feather_esp32s3_tft/platformio.ini
+++ b/variants/esp32s3/adafruit_feather_esp32s3_tft/platformio.ini
@@ -1,0 +1,21 @@
+[env:adafruit-feather-esp32s3-tft]
+board_level = extra
+extends = esp32s3_base
+board = adafruit_feather_esp32s3_tft
+board_build.mcu = esp32s3
+upload_protocol = esptool
+lib_deps =
+  ${esp32s3_base.lib_deps}
+  # renovate: datasource=custom.pio depName=NeoPixel packageName=adafruit/library/Adafruit NeoPixel
+  adafruit/Adafruit NeoPixel@1.15.3
+  # renovate: datasource=custom.pio depName=LovyanGFX packageName=lovyan03/library/LovyanGFX
+  lovyan03/LovyanGFX@1.2.19
+build_flags = 
+  ${esp32s3_base.build_flags}
+  -D PRIVATE_HW
+  -I variants/esp32s3/adafruit_feather_esp32s3_tft
+  -D USE_SX127x
+  -D HAS_SCREEN=1
+  -D LGFX_PANEL=ST7789
+  -D TFT_I2C_POWER=21
+  -D NEOPIXEL_POWER=34

--- a/variants/esp32s3/adafruit_feather_esp32s3_tft/variant.cpp
+++ b/variants/esp32s3/adafruit_feather_esp32s3_tft/variant.cpp
@@ -1,0 +1,21 @@
+#include "variant.h"
+
+/**
+ * Enable power to peripherals that require explicit power control.
+ * This function is called early during device initialization.
+ */
+void initVariant()
+{
+    // Enable power to NeoPixel
+#ifdef NEOPIXEL_POWER
+    pinMode(NEOPIXEL_POWER, OUTPUT);
+    digitalWrite(NEOPIXEL_POWER, HIGH);
+#endif
+
+    // Enable power to TFT display via I2C power pin
+    // This is used for powering the I2C pullup resistors and other TFT-related components
+#ifdef TFT_I2C_POWER
+    pinMode(TFT_I2C_POWER, OUTPUT);
+    digitalWrite(TFT_I2C_POWER, HIGH);
+#endif
+}

--- a/variants/esp32s3/adafruit_feather_esp32s3_tft/variant.h
+++ b/variants/esp32s3/adafruit_feather_esp32s3_tft/variant.h
@@ -1,0 +1,59 @@
+#define I2C_SDA 42
+#define I2C_SCL 41
+
+#define LED_PIN 13
+
+#define HAS_NEOPIXEL
+#define NEOPIXEL_COUNT 1
+#define NEOPIXEL_DATA 33
+#define NEOPIXEL_TYPE (NEO_GRB + NEO_KHZ800)
+#define NEOPIXEL_POWER 34
+
+#define BUTTON_PIN 0
+#define BUTTON_NEED_PULLUP
+
+// SPI (shared by LoRa and TFT)
+#define SPI_MOSI 35
+#define SPI_SCK 36
+#define SPI_MISO 37
+
+// RFM95/SX127x
+#define USE_RF95
+#define LORA_MISO SPI_MISO
+#define LORA_SCK SPI_SCK
+#define LORA_MOSI SPI_MOSI
+#define LORA_CS 6
+#define LORA_RESET 9
+#define LORA_IRQ 5
+#define LORA_DIO0 LORA_IRQ
+
+#define LORA_DIO1 RADIOLIB_NC
+#define LORA_DIO2 RADIOLIB_NC
+
+// TFT ST7789
+#define USE_TFTDISPLAY 1
+#define TFT_CS 7
+#define TFT_BL 45
+#define ST7789_CS TFT_CS
+#define ST7789_SDA SPI_MOSI
+#define ST7789_MISO SPI_MISO
+#define ST7789_SCK SPI_SCK
+#define ST7789_RS 39
+#define ST7789_RESET 40
+#define ST7789_BUSY -1
+#define ST7789_BL TFT_BL
+#define SPI_FREQUENCY 40000000
+#define SPI_READ_FREQUENCY 16000000
+#define ST7789_SPI_HOST SPI2_HOST
+#define TFT_I2C_POWER 21
+#define TFT_HEIGHT 320
+#define TFT_WIDTH 240
+
+// Experiment for 240x135 display on 240x320 panel
+#define ST7789_ALT
+#define TFT_PANEL_HEIGHT 240
+#define TFT_PANEL_WIDTH 135
+
+#define TFT_OFFSET_X 52
+#define TFT_OFFSET_Y 40
+#define TFT_OFFSET_ROTATION 0


### PR DESCRIPTION
The following code is to enable support for an Adafruit Feather ESP32-S3 TFT board that is connected to an Adafruit RFM95 Featherwing for LoRa capabilities. In addition to adding the custom `variants` files, I had to update the `TFTDisplay.cpp` core file to add a new capability in order to get the TFT to display correctly. I also noticed and fixed a bug in the `RF95INterface.cpp` code that caused this board to continually attempt to reset AGC. 