### PR TITLE
Adafruit feather esp32s3 TFT display improvements

### DIFF
--- a/src/graphics/TFTDisplay.cpp
+++ b/src/graphics/TFTDisplay.cpp
@@ -1184,9 +1184,17 @@ TFTDisplay::TFTDisplay(uint8_t address, int sda, int scl, OLEDDISPLAY_GEOMETRY g
     }
 
 #elif defined(SCREEN_ROTATE)
+#if defined(ST7789_ALT)
+    setGeometry(GEOMETRY_RAWMODE, TFT_PANEL_WIDTH, TFT_PANEL_HEIGHT);
+#else
     setGeometry(GEOMETRY_RAWMODE, TFT_HEIGHT, TFT_WIDTH);
+#endif
+#else
+#if defined(ST7789_ALT)
+    setGeometry(GEOMETRY_RAWMODE, TFT_PANEL_HEIGHT, TFT_PANEL_WIDTH);
 #else
     setGeometry(GEOMETRY_RAWMODE, TFT_WIDTH, TFT_HEIGHT);
+#endif
 #endif
 }
 

--- a/variants/esp32s3/adafruit_feather_esp32s3_tft/platformio.ini
+++ b/variants/esp32s3/adafruit_feather_esp32s3_tft/platformio.ini
@@ -14,7 +14,6 @@ build_flags =
   ${esp32s3_base.build_flags}
   -D PRIVATE_HW
   -I variants/esp32s3/adafruit_feather_esp32s3_tft
-  -D HAS_SCREEN=1
   -D LGFX_PANEL=ST7789
   -D TFT_I2C_POWER=21
   -D NEOPIXEL_POWER=34

--- a/variants/esp32s3/adafruit_feather_esp32s3_tft/platformio.ini
+++ b/variants/esp32s3/adafruit_feather_esp32s3_tft/platformio.ini
@@ -14,7 +14,6 @@ build_flags =
   ${esp32s3_base.build_flags}
   -D PRIVATE_HW
   -I variants/esp32s3/adafruit_feather_esp32s3_tft
-  -D USE_SX127x
   -D HAS_SCREEN=1
   -D LGFX_PANEL=ST7789
   -D TFT_I2C_POWER=21


### PR DESCRIPTION
I was able to identify the reason content kept running past the bottom of the screen on the Adafruit Feather ESP32-S3 TFT board. The `TFTDisplay` class was initializing the display using the `TFT_WIDTH` and `TFT_HEIGHT` values regardless of what was defined in the new `TFT_PANEL_WIDTH` and `TFT_PANEL_HEIGHT` options that I created earlier for this specific board. The `TFTDisplay.cpp` code was updated to utilize those new panel dimensions if the optional `ST7789_ALT` config is set.

There are also two quick commits included here that were part of some code cleanup. Those build flags were found to be redundant.